### PR TITLE
Remove GrooveBlockOption

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantSyncClientRestriction.md
@@ -28,7 +28,7 @@ You must be a SharePoint Online administrator or Global Administrator to run the
 
 Requires a valid `Connect-SPOService` context to identify the tenant. For information on how to connect to the tenant, see `Connect-SPOService`.
 
-The `Remove-SPOTenantSyncClientRestriction` cmdlet disables the feature for tenancy, but does not remove any present domain GUID entries from the safe sender recipient list. After the `Remove-SPOTenantSyncClientRestriction` cmdlet is run it can take up to 24 hours for change to take effect. This parameter will also remove any values set from the GrooveBlockOption parameter for syncing.
+The `Remove-SPOTenantSyncClientRestriction` cmdlet disables the feature for tenancy, but does not remove any present domain GUID entries from the safe sender recipient list. After the `Remove-SPOTenantSyncClientRestriction` cmdlet is run it can take up to 24 hours for change to take effect.
 
 The `Remove-SPOTenantSyncClientRestriction` cmdlet does not have any parameters.
 


### PR DESCRIPTION
Usage of GrooveBlockOption is discouraged.
Remove it from Remove-SPOTenantSyncClientRestriction